### PR TITLE
BF-187 PDP checkout double email sent

### DIFF
--- a/Controller/Checkout/ValidateOrder.php
+++ b/Controller/Checkout/ValidateOrder.php
@@ -233,13 +233,6 @@ class ValidateOrder extends \Bread\BreadCheckout\Controller\Checkout
             ->setLastSuccessQuoteId($quote->getId())
             ->clearHelperData();
 
-        try {
-            $this->orderSender->send($order);
-        } catch (\Exception $e) {
-            $this->logger->log(['MESSAGE' => $e->getMessage(), 'TRACE' => $e->getTraceAsString()]);
-            $this->customerSession->setBreadItemAddedToQuote(false);
-        }
-
         if ($customer->getId()) {
             $this->customerSession->setCustomerAsLoggedIn($customer);
         }


### PR DESCRIPTION
Removed code that caused sending double order confirmation email when checkout was done from PDP, email send is handled by magento event, so no need for this code.