### PR TITLE
Magento csp whitelist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Offers the Bread financing and checkout tools for your Magento store",
     "license": "MIT",
     "minimum-stability": "stable",
-    "version": "1.1.15",
+    "version": "1.1.16",
     "require": {
         "php": "~7.0.13||~7.1.0||~7.1.3||~7.2.0||~7.3.0"
     },

--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<csp_whitelist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Csp:etc/csp_whitelist.xsd">
+    <policies>
+        <policy id="script-src">
+            <values>
+                <value id="bread-sandbox-base" type="host">https://checkout-sandbox.getbread.com</value>
+                <value id="bread-production-base" type="host">https://checkout.getbread.com</value>
+            </values>
+        </policy>
+        <policy id="connect-src">
+            <values>
+                <value id="bread-sandbox" type="host">https://checkout-sandbox.getbread.com</value>
+                <value id="bread-production" type="host">https://checkout.getbread.com</value>
+            </values>
+        </policy>
+    </policies>
+</csp_whitelist>

--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -13,5 +13,11 @@
                 <value id="bread-production" type="host">https://checkout.getbread.com</value>
             </values>
         </policy>
+        <policy id="frame-src">
+            <values>
+                <value id="bread-sandbox" type="host">https://checkout-sandbox.getbread.com</value>
+                <value id="bread-production" type="host">https://checkout.getbread.com</value>
+            </values>
+        </policy>
     </policies>
 </csp_whitelist>


### PR DESCRIPTION
Magento version 1.1.16 release
1) Magento CSP whitelist for Bread externally loaded assets
2) Healthcare mode configuration update
3) Shipping method change fix on checkout page 